### PR TITLE
fix: upgrade conventional-actions to node24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0
       - name: Generate next version
         id: version
-        uses: conventional-actions/next-version@v1
+        uses: conventional-actions/next-version@1b3e4803a0bdf7435ba7bb5ace077445ed54e82a # v1.1.8
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
@@ -59,7 +59,7 @@ jobs:
       contents: write
     steps:
       - name: Create Release
-        uses: conventional-actions/create-release@v1
+        uses: conventional-actions/create-release@c025b7306d14a25901b72486f97f3ebe7662a8ed # v1.0.31
         with:
           tag_name: ${{ needs.build.outputs.version }}
           artifacts: "*"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0
       - name: Generate next version
         id: version
-        uses: conventional-actions/next-version@v1
+        uses: conventional-actions/next-version@1b3e4803a0bdf7435ba7bb5ace077445ed54e82a # v1.1.8
       - name: Setup Node
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
## Summary

Upgrade conventional-actions to node24-compatible releases:

- `conventional-actions/next-version` → **v1.1.8** (`1b3e480`)
- `conventional-actions/create-release` → **v1.0.31** (`c025b73`)

Node 20 reaches EOL April 2026 and GitHub is forcing migration to node24 by June 2026.

### Upstream PRs

- https://github.com/conventional-actions/next-version/pull/96
- https://github.com/conventional-actions/create-release/pull/8

## Test plan

- [ ] CI passes on this PR
